### PR TITLE
ISSUE #8 - Initial version of unit tests for random Generators and sdot

### DIFF
--- a/BLAS360.cabal
+++ b/BLAS360.cabal
@@ -46,6 +46,11 @@ library
 test-suite blas-test
   hs-source-dirs: test
   main-is: Main.hs
-  build-depends:    base, primitive, vector, tasty, BLAS360
+  other-modules:    Gen, OSX
+  build-depends:    base, primitive, vector, tasty, QuickCheck, tasty-hunit,
+      random, tasty-quickcheck, BLAS360
   type: exitcode-stdio-1.0
 
+  frameworks: Accelerate
+  extra-libraries: cblas
+  ghc-options: -Wall -Werror -msse2 -O1

--- a/stack.yaml
+++ b/stack.yaml
@@ -59,8 +59,8 @@ extra-package-dbs: []
 # arch: x86_64
 # 
 # Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]
+# extra-include-dirs: [/usr/local/lib]
+extra-lib-dirs: [/usr/local/lib]
 # 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -1,0 +1,241 @@
+-- | This module provides random number generators for floating point numbers
+-- and vectors thereof.    Generators for a variety of different ranges are
+-- provided to facilitate testing of important corner cases (e.g. Infinites,
+-- NaN, denormalized values, etc.).
+{-# LANGUAGE RankNTypes #-}
+module Gen
+   ( -- * Generators
+   genFloat
+   , genDouble
+   , genRealFloat
+   , genDenormalized
+   , genNegative
+   , genTiny
+   , genSmall
+   , genLarge
+   , genHuge
+   , genEveryday
+   , genVector
+   , genNVector
+   -- * Ranges
+   , denormalizedRange
+   , tinyRange
+   , smallRange
+   , everydayRange
+   , largeRange
+   , hugeRange
+   -- * Helper functions
+   , inRange
+   , alterFloat
+   , areAdjacent
+   ) where
+
+import System.Random
+import Test.QuickCheck.Gen
+import Data.Vector.Unboxed
+
+-- | Given a generator for the elements, construct a random vector of length
+-- between 1 and 1000.
+genVector :: (Unbox a) => Gen a -> Gen (Vector a)
+genVector gen = do
+    n<- choose (1,1000)
+    genNVector gen n
+
+-- | Given a generator for the elements, construct a
+-- random vector of the given length
+genNVector :: (Unbox a) => Gen a -> Int -> Gen (Vector a)
+genNVector gen n = vectorOf n gen >>= return.fromList
+
+-- | Given a random generator for a floating point type, generate a random
+-- Float value.
+genFloat :: (forall a. (RealFloat a, Random a)=> a -> Gen a) -> Gen Float
+genFloat gen = gen (1::Float)
+
+-- | Given a random generator for a floating point type, generate a random
+-- Double value.
+genDouble :: (forall a. (RealFloat a, Random a)=> a -> Gen a) -> Gen Double
+genDouble gen = gen (1::Double)
+
+-- | Generate a random floating value.  Nan and infinities will occur
+-- approximately 1% of the time.
+genRealFloat :: (Random a, RealFloat a) => a -> Gen a
+genRealFloat x = frequency
+    [(495,genNonNegative x)
+    ,(495,genNegative (genPositive x))
+    ,(4, return $ 1/0)  -- infinity
+    ,(4, return (-1/0)) -- neg infinity
+    ,(2, return (0/0))  -- NaN
+    ]
+
+-- | Given a generator for a real float, return a generator that
+-- negates the values.
+genNegative :: (RealFloat a) => Gen a -> Gen a
+genNegative gen = gen >>= return . negate
+
+-- | Generate a random positive real float value.
+genPositive :: (Random a, RealFloat a) => a -> Gen a
+genPositive x = frequency
+    [(50,genEveryday x)
+    ,(5,genDenormalized x)
+    ,(10,genTiny x)
+    ,(10,genLarge x)
+    ,(10,genSmall x)
+    ,(10,genHuge x)
+    ]
+
+-- | Generate a random non-negative real float value.  Zero will
+-- occur approximately 5% of the time.
+genNonNegative :: (Random a, RealFloat a) => a -> Gen a
+genNonNegative x = frequency
+    [(5,return 0)
+    ,(95,genPositive x)
+    ]
+
+-- | Generate a positive denormalized number of the given type.
+-- note: The built in haskell random instance for float will not
+-- reliably generate denormalized numbers (it will randomly generate
+-- zeros).   As a work around, we use the choose to generate
+-- the integer significand and encode float to construct the returned result.
+genDenormalized :: (RealFloat a) => a -> Gen a
+genDenormalized x = choose ( 1, r^(p-1)-1) >>= \ s ->
+    return $ encodeFloat (s*r^(2::Integer)) (m-p-2)
+    where
+    ( m , _ ) = floatRange x
+    r = floatRadix x
+    p = floatDigits x
+{-# SPECIALIZE genDenormalized :: Double -> Gen Double #-}
+{-# SPECIALIZE genDenormalized :: Float -> Gen Float #-}
+
+-- | Generate a random floating point number drawn from a
+-- uniform distribution between  approximately epilon and
+-- 1/epsilon.
+genEveryday :: (Random a, RealFloat a)=> a -> Gen a
+genEveryday x = choose $ everydayRange x
+{-# SPECIALIZE genEveryday :: Double -> Gen Double #-}
+{-# SPECIALIZE genEveryday :: Float -> Gen Float #-}
+
+-- | Generate a floating number between approximately
+-- 1/epsilon and the largest squarable number of the
+-- given type.
+genLarge :: (Random a, RealFloat a)=> a -> Gen a
+genLarge x = choose $ largeRange x
+{-# SPECIALIZE genLarge :: Double -> Gen Double #-}
+{-# SPECIALIZE genLarge :: Float -> Gen Float #-}
+
+-- | Generate a floating number between largest squarable number of
+-- the given type and the largest finite representable value of
+-- the type.
+genHuge :: (Random a, RealFloat a)=> a -> Gen a
+genHuge x = choose $ hugeRange x
+{-# SPECIALIZE genHuge :: Double -> Gen Double #-}
+{-# SPECIALIZE genHuge :: Float -> Gen Float #-}
+
+-- | Generate a floating number between approximately epsilon/2 and
+-- the smallest squareable non-denormalized number of the given type.
+genSmall :: (Random a, RealFloat a) => a -> Gen a
+genSmall x = choose $ smallRange x
+{-# SPECIALIZE genSmall :: Double -> Gen Double #-}
+{-# SPECIALIZE genSmall :: Float -> Gen Float #-}
+
+-- | Generate a random tiny number.   Tiny numbers are not denormalized, but
+-- they are so small that when they are squared, the result rounds to zero.
+genTiny :: (Random a, RealFloat a) => a -> Gen a
+genTiny x = choose (tinyRange x)
+{-# SPECIALIZE genTiny :: Float -> Gen Float #-}
+{-# SPECIALIZE genTiny :: Double -> Gen Double #-}
+
+-- Compute the range of non-denormalized numbers that when squared are equal to
+-- zero.  Assumes a radix of 2.
+tinyRange::(RealFloat a)=> a -> (a,a)
+{-# INLINE tinyRange #-}
+tinyRange x = (minA, maxA)
+  where
+  minA = alterFloat succ $ snd $ denormalizedRange x
+  maxA | (m-p) `mod` 2 /= 0 = encodeFloat 1 ((m-p-1) `div` 2)
+       | otherwise          = let (s,e) = decodeFloat $ (encodeFloat 1 ((m-p-2) `div` 2)) * sqrt (2::Double)
+                              in  encodeFloat (s-1) e
+  p = floatDigits x
+  (m,_)= floatRange x
+{-# SPECIALIZE tinyRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE tinyRange :: Float -> (Float,Float) #-}
+
+-- the range of denormalized numbers of a given type
+denormalizedRange :: (RealFloat a)=> a -> (a,a)
+{-# INLINE denormalizedRange #-}
+denormalizedRange x = ( encodeFloat 1 (m-p)
+                      , encodeFloat (r^(p-1)-1) (m-p))
+    where
+    r = floatRadix x
+    p = floatDigits x
+    (m,_) = floatRange x
+{-# SPECIALIZE denormalizedRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE denormalizedRange :: Float -> (Float,Float) #-}
+
+-- Huge numbers are infinte when squared.  Return the range of the huge
+-- numbers
+hugeRange :: (RealFloat a)=> a -> (a,a)
+{-# INLINE hugeRange #-}
+hugeRange x = ( minA, maxA )
+    where
+    maxA = encodeFloat (r^p -1) (m-p)
+    minA = encodeFloat 1 (m `div` 2)
+    r = floatRadix x
+    p = floatDigits x
+    (_,m) = floatRange x
+{-# SPECIALIZE hugeRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE hugeRange :: Float -> (Float,Float) #-}
+
+-- | Everyday range numbers are numbers that are between approximately
+-- epsilon and 1/epsilon.
+everydayRange :: (RealFloat a)=> a -> (a,a)
+{-# INLINE everydayRange #-}
+everydayRange x = ( encodeFloat 1 minExp
+    , encodeFloat (r^p-1) 0 )
+    where
+    r = floatRadix x
+    p = floatDigits x
+    minExp = negate $ p
+{-# SPECIALIZE everydayRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE everydayRange :: Float -> (Float,Float) #-}
+
+-- | Large range numbers are numbers that are between the everyday
+-- numbers and huge numbers.
+largeRange :: (RealFloat a)=> a -> (a,a)
+{-# INLINE largeRange #-}
+largeRange x = ( encodeFloat (succ s0) e0, encodeFloat (r^p -1) (m `div` 2 - p))
+    where
+    (_,m)=floatRange x
+    p = floatDigits x
+    r = floatRadix x
+    (s0,e0) = decodeFloat $ snd $ everydayRange x
+{-# SPECIALIZE largeRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE largeRange :: Float -> (Float,Float) #-}
+
+-- | Small range numbers are numbers that are between the tiny
+-- numbers and everyday numbers.
+smallRange :: (RealFloat a)=> a -> (a,a)
+{-# INLINE smallRange #-}
+smallRange x = ( encodeFloat (succ s0) e0, maxA)
+    where
+    p=floatDigits x
+    (s0,e0) = decodeFloat $ snd $ tinyRange x
+    maxA = fst (everydayRange x)-encodeFloat 1 (-2*p)
+{-# SPECIALIZE smallRange :: Double -> (Double,Double) #-}
+{-# SPECIALIZE smallRange :: Float -> (Float,Float) #-}
+
+-- | Test if an element is in a given range of values.   This predicate
+-- is used by the denormalizedTest, tinyTest, smallTest, everydayTest, largeTest,
+-- and hugeTest to confirm membership.
+inRange :: (Ord a) => (a,a) -> a -> Bool
+inRange (lb,ub) x = x>=lb && x<=ub
+
+-- | alter a float by applying an integer function to the significand.  This
+-- function is used to perform adjacency tests.
+alterFloat :: (RealFloat a)=> (Integer->Integer) -> a -> a
+alterFloat f x = let (s,e) = decodeFloat x
+                 in  encodeFloat (f s) e
+
+
+-- | Test to see if two ranges are adjacent
+areAdjacent :: (RealFloat a) => (a,a) -> (a,a) -> Bool
+areAdjacent (_,ub) (lb,_) = alterFloat succ ub == lb

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,5 +2,183 @@
 -- the native haskell implementations of BLAS subroutines.
 module Main( main ) where
 
+import qualified Data.Vector.Unboxed as V
+import Foreign.Marshal.Array
+import System.Random
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.Tasty.HUnit
+-- | This package
+import Numerical.BLAS.Single
+-- | This test suite
+import Gen
+import qualified OSX
+
+-- | Perform the tests
 main :: IO ()
-main = return ()
+main = defaultMain tests
+
+-- | A data structure containing all the tests that can be performed.
+tests :: TestTree
+tests = testGroup "BLAS"
+    [ genTests "Double" (1::Double) -- test the random number generators for IEEE Doubles
+    , genTests "Float"  (1::Float)  -- test the random number generators for IEEE Singles
+    , dotTests -- Confirm that the native sdot function is byte equivalent to the CBLAS implementation
+    ]
+
+-- | Evidence that the native sdot function is byte equivalent to the CBLAS
+-- implementation.  Vectors of length 1-10 are tested having elements that are
+-- in the range of approximately (epsilon/2,2/epsilon)
+dotTests :: TestTree
+dotTests = testProperty "sdot" $
+    -- Choose the length of the vector
+    forAll (choose (1,10)) $ \ n ->
+    -- Randomly generate two vectors of the chosen length
+    forAll (genNVector (genFloat genEveryday) n) $ \ u ->
+    forAll (genNVector (genFloat genEveryday) n) $ \ v ->
+       -- monadically marshal the vectors into arrays for use with CBLAS
+       ioProperty $
+       withArray (V.toList u) $ \ us ->
+       withArray (V.toList v) $ \ vs -> do
+           -- compute the expected and observed values
+           let expected = OSX.sdot n us 1 vs 1
+               observed = sdot n u 1 v 1
+           runTest expected observed
+      where
+      runTest expected observed =
+          if expected==observed
+                then return True
+                else do
+                    putStrLn ""
+                    putStrLn $ "EXPECTED: " ++ show expected
+                    putStrLn $ "OBSERVED: " ++ show observed
+                    return False
+
+-- | Test all the random number generators for a given floating point type.
+genTests :: (Random a, RealFloat a,Show a)=> String -> a -> TestTree
+genTests str x = testGroup str
+    [ denormalizedTest x
+    , tinyTest x
+    , hugeTest x
+    , everydayTest x
+    , largeTest x
+    , smallTest x
+    , testRanges x
+    ]
+
+-- | Produce evidence that the denormalized range contains only positive
+-- finite, denormalized values
+denormalizedTest :: ( RealFloat a,Show a)=> a -> TestTree
+denormalizedTest x = testGroup "genDenormalized"
+   [ testProperty "isDenormalized" $ forAll gen isDenormalized
+   , testProperty "isPositive" $ forAll gen (>0)
+   , testProperty "inRange" $ forAll gen (inRange (denormalizedRange x))
+   , testProperty "Not well scaled wrt 1" $ forAll gen (\ z -> z+1 == max z 1 )
+   ]
+   where
+   gen = genDenormalized x
+
+-- | Produce evidence that the tiny range contains only positive,
+-- non-denoralized, finite values that when squared are zero.
+tinyTest :: (Random a, RealFloat a,Show a)=> a->TestTree
+tinyTest x = testGroup "genTiny"
+   [ testProperty "isPositive" $ forAll gen (>0)
+   , testProperty "isNotDenormalized" $ forAll gen (not.isDenormalized)
+   , testProperty "Square is zero" $ forAll gen ((==0).(**2))
+   , testProperty "isNotZero" $ forAll gen (/=0)
+   , testProperty "isFinite" $ forAll gen (not.isInfinite)
+   , testProperty "isANumber" $ forAll gen (not.isNaN)
+   , testProperty "inRange" $ forAll gen (inRange (tinyRange x))
+   , testProperty "Not well scaled wrt 1" $ forAll gen (\ z -> z+1 == max z 1 )
+   ]
+   where
+   gen = genTiny x
+
+-- | Produce evidence that the huge numbers contain only positive,
+-- normalized, finite values that when squared are infinite.
+hugeTest :: (Random a, RealFloat a,Show a)=> a->TestTree
+hugeTest x = testGroup "genHuge"
+  [ testProperty "isPositive" $ forAll gen (>0)
+  , testProperty "isNotDenormalized" $ forAll gen (not.isDenormalized)
+  , testProperty "Square is Infinite" $ forAll gen (isInfinite.(**2))
+  , testProperty "isNotZero" $ forAll gen (/=0)
+  , testProperty "isFinite" $ forAll gen (not.isInfinite)
+  , testProperty "isANumber" $ forAll gen (not.isNaN)
+  , testProperty "inRange" $ forAll gen (inRange (hugeRange x))
+  , testProperty "Not well scaled wrt 1" $ forAll gen (\ z -> z+1 == max z 1)
+  ]
+  where
+  gen = genHuge x
+
+-- | Produce evidence that the everyday numbers contain only positive,
+-- normalized, finite values that are well scaled wrt unity.
+everydayTest :: (Random a, RealFloat a,Show a)=> a->TestTree
+everydayTest x = testGroup "genEveryday"
+    [ testProperty "isPositive" $ forAll gen (>0)
+    , testProperty "isNotDenormalized" $ forAll gen (not.isDenormalized)
+    , testProperty "Square is Finite" $ forAll gen (not.isInfinite.(**2))
+    , testProperty "Square is non-zero" $ forAll gen ((/=0).(**2))
+    , testProperty "isNotZero" $ forAll gen (/=0)
+    , testProperty "isFinite" $ forAll gen (not.isInfinite)
+    , testProperty "isANumber" $ forAll gen (not.isNaN)
+    , testProperty "inRange" $ forAll gen (inRange (everydayRange x))
+    , testProperty "Well scaled wrt 1" $ forAll gen (\ z -> z+1 > max z 1 )
+    ]
+    where
+    gen = genEveryday x
+
+-- | Produce evidence that the large range contains positive normalized finite numbers
+-- that are not well scaled wrt unity, nor are their squares finite or zero.
+largeTest :: (Random a, RealFloat a,Show a)=> a->TestTree
+largeTest x = testGroup "genLarge"
+    [ testProperty "isPositive" $ forAll gen (>0)
+    , testProperty "isNotDenormalized" $ forAll gen (not.isDenormalized)
+    , testProperty "Square is Finite" $ forAll gen (not.isInfinite.(**2))
+    , testProperty "Square is non-zero" $ forAll gen ((/=0).(**2))
+    , testProperty "isNotZero" $ forAll gen (/=0)
+    , testProperty "isFinite" $ forAll gen (not.isInfinite)
+    , testProperty "isANumber" $ forAll gen (not.isNaN)
+    , testProperty "inRange" $ forAll gen (inRange (largeRange x))
+    , testProperty "Not Well scaled wrt 1" $ forAll gen (\ z -> z+1 == max z 1 )
+    ]
+    where
+    gen = genLarge x
+
+-- | Produce evidence that the small range contains positive normalized finite numbers
+-- that are not well scaled wrt unity, nor are their squares finite or zero.
+smallTest :: (Random a, RealFloat a,Show a)=> a->TestTree
+smallTest x = testGroup "genSmall"
+    [ testProperty "isPositive" $ forAll gen (>0)
+    , testProperty "isNotDenormalized" $ forAll gen (not.isDenormalized)
+    , testProperty "Square is Finite" $ forAll gen (not.isInfinite.(**2))
+    , testProperty "Square is non-zero" $ forAll gen ((/=0).(**2))
+    , testProperty "isNotZero" $ forAll gen (/=0)
+    , testProperty "isFinite" $ forAll gen (not.isInfinite)
+    , testProperty "isANumber" $ forAll gen (not.isNaN)
+    , testProperty "inRange" $ forAll gen (inRange (smallRange x))
+    , testProperty "Not Well scaled wrt 1" $ forAll gen (\ z -> z+1 == max z 1 )
+    ]
+    where
+    gen = genSmall x
+
+-- | Confirm that the denormalized, tiny, small, everyday, large and huge ranges
+-- are adjacent and cover all the finite representable floating point numbers.
+testRanges :: ( RealFloat a) => a -> TestTree
+testRanges x = testGroup "Ranges cover all values" [
+    testCase "includes largest finite value" $
+        assertBool "largest value is excluded" ubIsLargest,
+    testCase "includes smallest positive value" $
+        assertBool "smallest positive value is excluded" lbIsSmallest,
+    testCase "ranges are adjacent" $
+        assertBool "ranges are not adjacent" coversRange
+    ]
+    where
+    p = floatDigits x
+    (m,_) = floatRange x
+    ubIsLargest = isInfinite (alterFloat succ (snd $ hugeRange x))
+    lbIsSmallest = (fst $ denormalizedRange x) == encodeFloat 1 (m-p)
+    coversRange = areAdjacent (denormalizedRange x) (tinyRange x)
+                 && areAdjacent (tinyRange x) (smallRange x)
+                 && areAdjacent (smallRange x) (everydayRange x)
+                 && areAdjacent (everydayRange x) (largeRange x)
+                 && areAdjacent (largeRange x) (hugeRange x)

--- a/test/OSX.hs
+++ b/test/OSX.hs
@@ -1,0 +1,9 @@
+-- | This module defines the Foreign function calls to CBLAS library.  For
+-- full documentation consult <http://www.netlib.org/blas/>.
+{-# LANGUAGE ForeignFunctionInterface #-}
+module OSX(sdot) where
+
+import Foreign.Ptr
+
+foreign import ccall "cblas_sdot"
+   sdot :: Int -> Ptr Float -> Int -> Ptr Float -> Int ->  Float


### PR DESCRIPTION
This pull request implements a unit test to demonstrate the byte equivalence of the haskell sdot function.   Since the test relies upon generators for floating point number over various ranges, a previously untested feature, we introduce unit tests for the random number generators as well

These tests as a whole provide evidence that
1) The implementation of sdot is correct up to the implementation of CBLAS
2) The ranges of the random number generators cover the entire range of numeric floating point values
3) Each random number generator creates a specification correct subset of the floating point number set (e.g. denormalized values, numbers that can be safely squared, etc).

