### PR TITLE
Issue #7 - create benchmarks for sdot function

### DIFF
--- a/BLAS360.cabal
+++ b/BLAS360.cabal
@@ -54,3 +54,14 @@ test-suite blas-test
   frameworks: Accelerate
   extra-libraries: cblas
   ghc-options: -Wall -Werror -msse2 -O1
+
+benchmark blas-benchmark
+    hs-source-dirs: test
+    main-is: Bench.hs
+    other-modules:    Gen, OSX
+    build-depends:    base, primitive, vector, QuickCheck,
+        random, criterion, BLAS360
+    type: exitcode-stdio-1.0
+    frameworks: Accelerate
+    extra-libraries: cblas
+    ghc-options: -msse2 -O1

--- a/src/Numerical/BLAS/Single.hs
+++ b/src/Numerical/BLAS/Single.hs
@@ -1,11 +1,20 @@
 -- | This module provides BLAS library functions for vectors of
 -- single precision floating point numbers.
 module Numerical.BLAS.Single(
-    sdot
+   sdot_zip,
+   sdot,
     ) where
 
 import Data.Vector.Unboxed(Vector)
 import qualified Data.Vector.Unboxed as V
+
+{- | O(n) compute the dot product of two vectors using zip and fold
+-}
+sdot_zip :: Vector Float -- ^ The vector u
+    -> Vector Float      -- ^ The vector v
+    -> Float             -- ^ The dot product u . v
+sdot_zip u v = V.foldr (+) 0 $ V.zipWith (*) u v
+
 
 {- | O(n) sdot computes the sum of the products of elements drawn from two
    vectors according to the following specification:

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -1,0 +1,39 @@
+-- | This module contains the benchmark test to compare the time
+-- performance of the Naive, Native Haskell and CBLAS implementations of
+-- the BLAS subroutines
+module Main( main ) where
+
+import qualified Data.Vector.Unboxed as V
+import Foreign.Marshal.Array
+import System.Random
+import Test.QuickCheck.Gen
+import Foreign.Ptr
+import Criterion.Main
+-- | This package
+import Numerical.BLAS.Single
+-- | This test suite
+import Gen
+import qualified OSX
+
+main :: IO ()
+main = do
+    u<- generate $ genNVector (genFloat genEveryday) 10001
+    v<- generate $ genNVector (genFloat genEveryday) 10001
+    withArray (V.toList u) $ \ us ->
+       withArray (V.toList v) $ \ vs ->
+        defaultMain $ benchmarks u v us vs
+
+benchmarks :: V.Vector Float -> V.Vector Float
+           -> Ptr Float -> Ptr Float
+           -> [Benchmark]
+benchmarks u v us vs = [ bgroup "sdot"
+   [ bench "naive" $ nf naive (u,v)
+   , bench "native" $ nf native (n,u,v)
+   , bench "cblas" $ nf cblas (n,us,vs)
+   ]
+   ]
+   where
+   n = V.length u
+   native (a,b,c) = sdot a b 1 c 1
+   cblas  (a,b,c) = OSX.sdot a b 1 c 1
+   naive (a,b) = sdot_zip a b


### PR DESCRIPTION
This pull request introduces a benchmark suite for comparing the naive, native haskell and CBLAS implmentations of the BLAS functions.     The benchmark suite can be invoked using 

stack bench

Build logs follow:

[benchmark.txt](https://github.com/dlewissandy/blas/files/688762/benchmark.txt)
[build.txt](https://github.com/dlewissandy/blas/files/688763/build.txt)

